### PR TITLE
Don't block on write to channel

### DIFF
--- a/server.go
+++ b/server.go
@@ -10,7 +10,9 @@ import (
 
 // Listen creates a UDP server that parses collectd data into packets and
 // sends them over a channel.
-func Listen(addr string, c chan Packet) {
+// The caller is responsible for ensuring that the channel is ready to receive
+// data, otherwise packets will be dropped
+func Listen(addr string, c chan<- Packet) {
 	laddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		log.Fatalln("fatal: failed to resolve address", err)
@@ -21,16 +23,22 @@ func Listen(addr string, c chan Packet) {
 	}
 	for {
 		buf := make([]byte, 1452)
-		n, err := conn.Read(buf[:])
+		n, err := conn.Read(buf)
 		if err != nil {
-			log.Println("error: Failed to recieve packet", err)
+			log.Println("error: Failed to receive packet", err)
 		} else {
 			packets, err := Parse(buf[0:n])
 			if err != nil {
-				log.Println("error: Failed to recieve packet", err)
+				log.Println("error: Failed to receive packet", err)
 			}
 			for _, p := range *packets {
-				c <- p
+				select {
+				case c <- p:
+					// packet sent to channel
+				default:
+					// don't block if channel isn't ready
+					log.Println("error: Channel not ready for write. Packet dropped.")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
It shouldn't be left up to the network buffer to handle slow consumers. Consumers should provide an appropriately sized buffered channel when calling `Listen()`
